### PR TITLE
Clean up train_template.yml

### DIFF
--- a/codes/options/train/train_template.yml
+++ b/codes/options/train/train_template.yml
@@ -1,313 +1,421 @@
-name: debug_001_template # use "debug" or "debug_nochkp" in the name to run a test session and check everything is working. Does validation and state saving every 8 iterations.
-#name: 001_template # remove "debug" to run the real training session.
+# > Term Legend:
+# tb: tensorboard
+# amp: Automatic Mixed Precision
+# hr: high-resolution a.k.a. ground truth images
+# lr: low-resolution images
+# otf: on-the-fly (automated)
+# nf: Number of discrim filters in the first conv layer
+# nb: Number of blocks
+# in_nc: Number of of input image color channels, e.g. `3` for R G B, `1` for Grayscale
+# out_nc: Number of of output image color channels, e.g. `3` for R G B, `1` for Grayscale
+
+
+# use "debug" or "debug_nochkp" in the name to run a test session and check everything is working. Does validation and state saving every 8 iterations.
+# due to increased rates of various settings when debugging, make sure you remove "debug" when running a real training session.
+name: debug_001_template
 use_tb_logger: true
-model: srragan #srragan | sr | srgan | ppon | asrragan
+model: srragan  # srragan | sr | srgan | ppon | asrragan
 scale: 4
 gpu_ids: [0]
 use_amp: true
 
 # Dataset options:
 datasets:
-  train: 
+
+  # Train dataset is the main bulk of your images that it will use to learn from
+  train:
+
+    # == #
+    # > Name
     name: DIV2K
+    # == #
+
+    # == #
+    # > Mode
+    # With `LRHROTF`, if there's no LR image with the same relative path as HR, then the LR will be generated on-the-fly from the HR image.
     mode: LRHROTF
-    # dataroot_HR: '../datasets/train/hr' # Original, with a single directory
-    # dataroot_LR: '../datasets/train/lr' # Original, with a single directory
-    dataroot_HR: [
-      '../datasets/train/hr1', 
-      '../datasets/train/hr2', 
-      '../datasets/train/hr3'
-      ] # high resolution / ground truth images
-    dataroot_LR: [
-      '../datasets/train/lr1', 
-      '../datasets/train/lr2' #,
-      # '../datasets/train/lr3'
-      ] # low resolution images. If there are missing LR images, they will be generated on the fly from HR
-    subset_file: null
-    use_shuffle: true
-    znorm: false # true | false # To normalize images in [-1, 1] range. Default = None (range [0,1]). Can use with activation function like tanh.
-    n_workers: 4 # 0 to disable CPU multithreading, or an integrer representing CPU threads to use for dataloading
+    # == #
+
+    # == #
+    # > Environment settings
+    n_workers: 4  # 0 = disable CPU multi-threading, otherwise an integer representing CPU threads to use for data-loading
     batch_size: 8
     virtual_batch_size: 8
-    HR_size: 128 # patch size. Default: 128. Needs to be coordinated with the patch size of the features network
-    image_channels: 3 # number of channels to load images in
+    # == #
 
-    # Color space conversion: 'color' for both LR and HR, 'color_LR' for LR independently, 'color_HR' for HR independently
-    # color: 'y' # remove for no conversion (RGB) | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
-    # color_LR: 'y' # remove for no conversion (RGB) | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
-    # color_HR: 'y' # remove for no conversion (RGB) | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
-    
-    # LR and HR modifiers. Random flip LR and HR or ignore provided LRs and generate new ones on the fly with defined probability:
-    # rand_flip_LR_HR: false # true # flip LR and HR during training.
-    # flip_chance: 0.05 # Example: 0.05 = 5% chance of LR and HR flipping during training.
-    # aug_downscale: 0.2 # Example: 0.6 = 60% chance of generating LR on the fly, even if LR dataset exists
-    
-    # If manually configuring on the fly generation of LR: (else, it will automatically default to Matlab-like downscale algorithm (777) when/if required
-    lr_downscale: true # false
-    lr_downscale_types: ["linear", "cubic", "matlab_bicubic"] # select from ["nearest", "linear", "cubic", "area", "lanczos4", "linear_exact", "matlab_bicubic"] #scale_algos #scaling interpolation options
+    # == #
+    # > Dataset
+    # dataroot options may also be a string pointing to one directory
+    # HR == high-resolution (a.k.a. ground truth) images
+    dataroot_HR: [
+      "../datasets/train/hr1",
+      "../datasets/train/hr2",
+      "../datasets/train/hr3",
+    ]
+    # LR == low-resolution images
+    dataroot_LR: [
+      '../datasets/train/lr1',
+      '../datasets/train/lr2',
+      # '../datasets/train/lr3',
+    ]
+    # HR images patch size. Default = 128. Needs to be coordinated with the patch size of the features network
+    HR_size: 128
+    # number of color channels to load the images in
+    image_channels: 3
+    # normalize images in [-1, 1] range. Default = false (range [0, 1]). Can use with activation function like tanh.
+    znorm: false
+    subset_file: ~
+    use_shuffle: true
+    # == #
 
-    # Rotations augmentations:
-    use_flip: true # flip images
-    use_rot: true # rotate images in 90 degree angles
-    hr_rrot: false # rotate images in random degress between -45 and 45
-    
-    # Noise and blur augmentations:
-    lr_blur: false # true | false
-    lr_blur_types: {gaussian: 1, clean: 3} # select from: "average","box","gaussian","bilateral","clean" ##blur options #median and motion aren't working yet
+    # == #
+    # > Color Space Converstion
+    # `color` will apply to both LR and HR, whereas `color_LR` and `color_HR` applies to LR and HR respectively.
+    color: ~     # ~ = disable | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
+    color_LR: ~  # ~ = disable | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
+    color_HR: ~  # ~ = disable | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
+    # == #
+
+    # == #
+    # > LR and HR augmentations
+    # Random flip LR and HR or ignore provided LRs and generate new ones on the fly with defined probability:
+    rand_flip_LR_HR: false  # swap LR with HR randomly while training under chance specified below
+    flip_chance: 0.05       # 0 = 0%, 1 = 100%
+    # On-the-fly LR
+    aug_downscale: 0  # e.g. 0.2 = 20% chance of generating LR on-the-fly, even if LR dataset exists
+    lr_downscale: true  # If manually configuring on-the-fly generation of LR, otherwise it will default to Matlab-like downscale algorithm (777) when/if required
+    lr_downscale_types: ["linear", "cubic", "matlab_bicubic"] # interpolation, select from ["nearest", "linear", "cubic", "area", "lanczos4", "linear_exact", "matlab_bicubic"]
+    # Rotation augmentations
+    use_flip: true  # flip images
+    use_rot: true   # rotate images in 90 degree angles
+    hr_rrot: false  # rotate images in random degress between -45 and 45
+    # Blur augmentations
+    lr_blur: false
+    lr_blur_types: {gaussian: 1, clean: 3}  # select from: "average","box","gaussian","bilateral","clean" ##blur options #median and motion aren't working yet
+    # Noise augmentations
     noise_data: ../noise_patches/normal/
-    lr_noise: false # true | false
-    lr_noise_types: {gaussian: 1, JPEG: 1, clean: 4} # select from: "gaussian", "JPEG", "quantize", "poisson", "dither", "s&p", "speckle", "patches", "clean"
-    lr_noise2: false # true | false
-    lr_noise_types2: {dither: 2, clean: 2} # select from: "gaussian", "JPEG", "quantize", "poisson", "dither", "s&p", "speckle", "patches", "clean"
-    hr_noise: false # true | false
-    hr_noise_types:  {gaussian: 1, clean: 4} # select from: "gaussian", "JPEG", "quantize", "poisson", "dither", "s&p", "speckle", "clean"
-    
-    # Color augmentations
-    # lr_fringes: true # true | false
-    # lr_fringes_chance: 0.4
-    # auto_levels: HR # "HR" | "LR" | "Both" #add auto levels to the images to expand dynamic range. Can use with SPL loss or (MS)-SSIM.
-    # rand_auto_levels: 0.7 # Example: 0.4 = 40% chance of adding auto levels to images on the fly
-    # lr_unsharp_mask: true # add a unsharpening mask to LR images. Can work well together with the HFEN loss function.
-    # lr_rand_unsharp: 1 # Example: 0.5 = 50% chance of adding unsharpening mask to LR images on the fly
-    # hr_unsharp_mask: true # add a unsharpening mask to HR images. Can work well together with the HFEN loss function.
-    # hr_rand_unsharp: 1 # Example: 0.5 = 50% chance of adding unsharpening mask to HR images on the fly
-    
-    # Augmentations for classification or (maybe) inpainting networks:
-    # lr_cutout: false # true | false
-    # lr_erasing: false # true | false
+    lr_noise: false
+    lr_noise_types: {gaussian: 1, JPEG: 1, clean: 4}  # select from: "gaussian", "JPEG", "quantize", "poisson", "dither", "s&p", "speckle", "patches", "clean"
+    lr_noise2: false
+    lr_noise_types2: {dither: 2, clean: 2}  # select from: "gaussian", "JPEG", "quantize", "poisson", "dither", "s&p", "speckle", "patches", "clean"
+    hr_noise: false
+    hr_noise_types:  {gaussian: 1, clean: 4}  # select from: "gaussian", "JPEG", "quantize", "poisson", "dither", "s&p", "speckle", "clean"
+    # == #
 
-  val: 
+    # == #
+    # > Color augmentations
+    lr_fringes: false
+    lr_fringes_chance: 0    # 0 = 0%, 1 = 100%
+    auto_levels: ~          # "HR" | "LR" | "Both", add auto levels to the images to expand dynamic range. Can use with SPL loss or (MS)-SSIM.
+    rand_auto_levels: ~     # Example: 0.4 = 40% chance of adding auto levels to images on-the-fly
+    lr_unsharp_mask: false  # add an unsharpening mask to LR images. Can work well together with the HFEN loss function.
+    lr_rand_unsharp: 0      # Example: 0.5 = 50% chance of adding unsharpening mask to LR images on-the-fly
+    hr_unsharp_mask: false  # add an unsharpening mask to HR images. Can work well together with the HFEN loss function.
+    hr_rand_unsharp: 0      # Example: 0.5 = 50% chance of adding unsharpening mask to HR images on-the-fly
+    # == #
+
+    # == #
+    # > Classification augmentations for (maybe) inpainting networks
+    lr_cutout: false
+    lr_erasing: false
+    # == #
+
+  # Validation dataset is a collection of images it will use to test for Perceptual index and saving tests of the current state
+  # This dataset doesn't need anything particular, pick any images from your `train` dataset you wish to look at to check if
+  # it's learning correct and to see if it's working. Do pick a nice range of images so Perceptual indexing can get accurate
+  # measurements. So don't have all your validation images from the same similar scene, or the same lighting and what not.
+  # These images can still be in the `train` dataset and don't have to be unique.
+  val:
+
+    # == #
+    # > Name
     name: val_set14_part
+    # == #
+
+    # == #
+    # > Mode
+    # With `LRHROTF`, if there's no LR image with the same relative path as HR, then the LR will be generated on-the-fly from the HR image.
     mode: LRHROTF
+    # == #
+
+    # == #
+    # > Dataset
+    # Unlike train dataset, these dataroot options must be a string pointing to only one directory
+    # HR == high-resolution (a.k.a. ground truth) images
     dataroot_HR: '../datasets/val/hr'
+    # LR == low-resolution images
     dataroot_LR: '../datasets/val/lr'
-    
-    znorm: false # true | false # To normalize images in [-1, 1] range. Default = None (range [0,1]). Can use with activation function like tanh.
-    
-    # Color space conversion: 'color' for both LR and HR, 'color_LR' for LR independently, 'color_HR' for HR independently
-    # color: 'y' # remove for no conversion (RGB) | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
-    # color_LR: 'y' # remove for no conversion (RGB) | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
-    # color_HR: 'y' # remove for no conversion (RGB) | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
-    
-    # hr_crop: false #disabled
+    # normalize images in [-1, 1] range. Default = false (range [0, 1]). Can use with activation function like tanh.
+    znorm: false
+    # == #
+
+    # == #
+    # > Color Space Converstion
+    # `color` will apply to both LR and HR, whereas `color_LR` and `color_HR` applies to LR and HR respectively.
+    color: ~     # ~ = disable | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
+    color_LR: ~  # ~ = disable | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
+    color_HR: ~  # ~ = disable | 'y' for Y in YCbCr | 'gray' to convert RGB to grayscale | 'RGB' to convert gray to RGB
+    # == #
+
+    # == #
+    # > LR and HR augmentations
+    hr_crop: false
     lr_downscale: false
-    lr_downscale_types: ["linear", "cubic"] # select from ["nearest", "linear", "cubic", "area", "lanczos4", "linear_exact", "matlab_bicubic"] #scale_algos #scaling interpolation options
+    lr_downscale_types: ["linear", "cubic"] # select from ["nearest", "linear", "cubic", "area", "lanczos4", "linear_exact", "matlab_bicubic"]
+    # == #
+
+# Workflow:
 path:
-    strict: false # true | false 
-    root: 'D:/Code/GitHub/BasicSR'
-    pretrain_model_G: '../experiments/pretrained_models/RRDB_PSNR_x4.pth'
-    #pretrain_model_G: '../experiments/pretrained_models/RRDB_ESRGAN_x4.pth'
-    #pretrain_model_G: '../experiments/pretrained_models/nESRGANplus.pth'
-    #pretrain_model_G: '../experiments/pretrained_models/PPON_G.pth'
-    # pretrain_model_G: '../experiments/pretrained_models/PANx4_DF2K.pth'
-    #resume_state: '../experiments/debug_002_RRDB_ESRGAN_x4_DIV2K/training_state/16.state'
 
-# Generator options:
+  strict: false
+  root: "D:/Code/GitHub/BasicSR"  # root path of the BasicSR repository
+  pretrain_model_G: "../experiments/pretrained_models/RRDB_PSNR_x4.pth"
+  #pretrain_model_G: "../experiments/pretrained_models/RRDB_ESRGAN_x4.pth"
+  #pretrain_model_G: "../experiments/pretrained_models/nESRGANplus.pth"
+  #pretrain_model_G: "../experiments/pretrained_models/PPON_G.pth"
+  # pretrain_model_G: "../experiments/pretrained_models/PANx4_DF2K.pth"
+  #resume_state: "../experiments/debug_002_RRDB_ESRGAN_x4_DIV2K/training_state/16.state"
+
+# Generator Network:
 network_G:
-    # ESRGAN:
-    which_model_G: RRDB_net # RRDB_net | sr_resnet
-    norm_type: null
-    mode: CNA
-    nf: 64 # of discrim filters in the first conv layer
-    nb: 23
-    in_nc: 3 # of input image channels: 3 for RGB and 1 for grayscale
-    out_nc: 3 # of output image channels: 3 for RGB and 1 for grayscale
-    gc: 32
-    group: 1
-    convtype: Conv2D # Conv2D | PartialConv2D
-    net_act: leakyrelu # swish | leakyrelu
-    gaussian: true # true | false
-    plus: false # true | false
-    ##finalact: tanh # Test. Activation function to make outputs fit in [-1, 1] range. Default = None. Coordinate with znorm.
 
-    # ASRGAN:
-    #which_model_G: asr_resnet # asr_resnet | asr_cnn
-    #nf: 64
+  # Note: Only the options for the network you wish to use should be uncommented.
 
-    # PPON:
-    #which_model_G: ppon # | ppon
-    ##norm_type: null
-    #mode: CNA
-    #nf: 64
-    #nb: 24
-    #in_nc: 3
-    #out_nc: 3
-    ##gc: 32
-    #group: 1
-    ##convtype: Conv2D #Conv2D | PartialConv2D
-    
-    # SRGAN:
-    #which_model_G: sr_resnet # RRDB_net | sr_resnet
-    #norm_type: null
-    #mode: CNA
-    #nf: 64
-    #nb: 16
-    #in_nc: 3
-    #out_nc: 3
-    
-    # SR:
-    #which_model_G: RRDB_net # RRDB_net | sr_resnet
-    #norm_type: null
-    #mode: CNA
-    #nf: 64
-    #nb: 23
-    #in_nc: 3
-    #out_nc: 3
-    #gc: 32
-    #group: 1
+  # == #
+  # ESRGAN:
+  which_model_G: RRDB_net  # RRDB_net | sr_resnet
+  norm_type: ~
+  mode: CNA
+  nf: 64
+  nb: 23
+  in_nc: 3
+  out_nc: 3
+  gc: 32
+  group: 1
+  convtype: Conv2D    # Conv2D | PartialConv2D
+  net_act: leakyrelu  # swish | leakyrelu
+  gaussian: true
+  plus: false
+  finalact: ~  # e.g. `tanh` Test. Activation function to make outputs fit in [-1, 1] range. Default = None. Coordinate with znorm.
+  # == #
 
-    # PAN:
-    # which_model_G: pan_net
-    # in_nc: 3
-    # out_nc: 3
-    # nf: 40
-    # unf: 24
-    # nb: 16
-    # self_attention: true
-    # double_scpa: false
+  # == #
+  # ASRGAN:
+  # which_model_G: asr_resnet  # asr_resnet | asr_cnn
+  # nf: 64
+  # == #
 
-# Discriminator options:
+  # == #
+  # PPON:
+  # which_model_G: ppon
+  # norm_type: ~
+  # mode: CNA
+  # nf: 64
+  # nb: 24
+  # in_nc: 3
+  # out_nc: 3
+  # #gc: 32
+  # group: 1
+  # #convtype: Conv2D  # Conv2D | PartialConv2D
+  # == #
+
+  # == #
+  # SRGAN:
+  # which_model_G: sr_resnet  # RRDB_net | sr_resnet
+  # norm_type: ~
+  # mode: CNA
+  # nf: 64
+  # nb: 16
+  # in_nc: 3
+  # out_nc: 3
+  # == #
+
+  # == #
+  # SR:
+  # which_model_G: RRDB_net  # RRDB_net | sr_resnet
+  # norm_type: ~
+  # mode: CNA
+  # nf: 64
+  # nb: 23
+  # in_nc: 3
+  # out_nc: 3
+  # gc: 32
+  # group: 1
+  # == #
+
+  # == #
+  # PAN:
+  # which_model_G: pan_net
+  # in_nc: 3
+  # out_nc: 3
+  # nf: 40
+  # unf: 24
+  # nb: 16
+  # self_attention: true
+  # double_scpa: false
+  # == #
+
+# Discriminator network:
 network_D:
-    # ESRGAN (default)| PPON:
-    which_model_D: discriminator_vgg # discriminator_vgg_128 | discriminator_vgg | discriminator_vgg_128_fea (feature extraction) | patchgan | multiscale
-    norm_type: batch
-    act_type: leakyrelu
-    mode: CNA # CNA | NAC
-    nf: 64
-    in_nc: 3
-    nlayer: 3 # only for patchgan and multiscale
-    num_D: 3 # only for multiscale
+
+  # == #
+  # ESRGAN | PPON:
+  which_model_D: discriminator_vgg  # discriminator_vgg_128 | discriminator_vgg | discriminator_vgg_128_fea (feature extraction) | patchgan | multiscale
+  norm_type: batch
+  act_type: leakyrelu
+  mode: CNA  # CNA | NAC
+  nf: 64
+  in_nc: 3
+  nlayer: 3  # only for patchgan and multiscale
+  num_D: 3  # only for multiscale
+  # == #
 
 # Schedulers options:
 train:
-    lr_G: 0.0001 # 2e-4 # starting lr_g #Test, default: 1e-4
-    weight_decay_G: 0
-    beta1_G: 0.9
-    lr_D: 0.0001 # 2e-4 # starting lr_d #Test, default: 1e-4
-    weight_decay_D: 0
-    beta1_D: 0.9
 
-    # For MultiStepLR (ESRGAN, default):
-    lr_scheme: MultiStepLR
-    lr_steps: [50000, 100000, 200000, 300000] # training from scratch
-    #lr_steps: [50000, 75000, 85000, 100000] #finetuning
-    lr_gamma: 0.5 # lr change at every step (multiplied by)
+  # Generator
+  lr_G: 1e-4  # starting lr_g
+  weight_decay_G: 0
+  beta1_G: 0.9
+  # Discriminator
+  lr_D: 1e-4  # starting lr_d
+  weight_decay_D: 0
+  beta1_D: 0.9
 
-    # For StepLR_Restart (PPON):
-    # lr_gamma: 0.9 #lr change at every step (multiplied by)
-    # lr_scheme: StepLR_Restart # MultiStepLR | MultiStepLR_Restart | StepLR | StepLR_Restart | CosineAnnealingLR_Restart
-    # lr_step_sizes: [200, 100, 250] # Steps for each restart for "StepLR_Restart"
-    # restarts: [138000, 172500] # Restart iterations for "MultiStepLR_Restart", "StepLR_Restart" and "CosineAnnealingLR_Restart"
-    # restart_weights: [1, 0.5, 0.5] #lr_() * each weight in "restart_weights" for each restart in "restarts"    
-    ##clear_state: true
-    
-    # For MultiStepLR_Restart:
-    # lr_gamma: 0.9
-    # lr_scheme: MultiStepLR_Restart # MultiStepLR | MultiStepLR_Restart | StepLR | StepLR_Restart | CosineAnnealingLR_Restart
-    # lr_steps: [34500, 69000, 103500, 155250, 189750, 241500] #For "MultiStepLR" and "MultiStepLR_Restart"
-    # restarts: [138000, 172500] # Restart iterations for "MultiStepLR_Restart", "StepLR_Restart" and "CosineAnnealingLR_Restart"
-    # restart_weights: [0.5, 0.5] # lr_() * each weight in "restart_weights" for each restart in "restarts"
-    ##clear_state: true
+  # For MultiStepLR (ESRGAN, default):
+  lr_scheme: MultiStepLR
+  lr_steps: [50000, 100000, 200000, 300000]  # training from scratch
+  #lr_steps: [50000, 75000, 85000, 100000]   #finetuning
+  lr_gamma: 0.5  # lr change at every step (multiplied by)
 
-    # For CosineAnnealingLR_Restart (PAN)
-    # lr_G: !!float 7e-4
-    # lr_scheme: "CosineAnnealingLR_Restart"
-    # beta1_G: 0.9
-    # beta2_G: 0.99
-    # lr_D: 7e-4
-    # beta1_D: 0.9
-    # beta2_D: 0.99
-    # # beta1: 0.9
-    # # beta2: 0.99
-    # niter: 1000000
-    # warmup_iter: -1  # no warm up
-    # T_period: [250000, 250000, 250000, 250000]
-    # restarts: [250000, 500000, 750000]
-    # restart_weights: [1, 1, 1]
-    # eta_min: !!float 1e-7
-    
-    # Losses:
-    pixel_criterion: cb # "l1" | "l2" | "cb" | "elastic" | "relativel1" | "l1cosinesim" | "clipl1" #pixel loss
-    pixel_weight: 1e-2 # 1e-2 | 1
-    feature_criterion: cb # "l1" | "l2" | "cb" | "elastic" #feature loss (VGG feature network)
-    feature_weight: 1
-    # cx_weight: 0.5
-    # cx_type: contextual
-    # cx_vgg_layers: {conv_3_2: 1, conv_4_2: 1}
-    # hfen_criterion: l1 # hfen: "l1" | "l2" | "rel_l1" | "rel_l2" #helps in deblurring and finding edges, lines
-    # hfen_weight: 1e-6 
-    # grad_type: grad-4d-l1 # 2d | 4d / - any of the pixel crit, ie "grad-2d-l1"
-    # grad_weight: 4e-1 # 4e-1
-    # tv_type: 4D # "normal" | "4D" #helps in denoising, reducing upscale artefacts
-    # tv_weight: 1e-5 # Change "tv_weight" so the l_g_tv is around 1e-02 - 1e-01
-    # tv_norm: 1 # 1 for l1 (default) or 2 for l2.
-    # ssim_type: ssim # "ssim" | "ms-ssim" #helps to maintain luminance, contrast and covariance between SR and HR
-    # ssim_weight: 1
-    # lpips_weight: 1 # perceptual loss
-    # lpips_type: net-lin # net-lin | net *
-    # lpips_net: squeeze # "vgg" | "alex" | "squeeze" 
-    
-    # Experimental losses
-    # spl_type: spl # "spl" | "gpl" | "cpl"
-    # spl_weight: 0.1 # 1e-2 # SPL loss function. note: needs to add a cap in the generator (finalcap; For [0,1] range -> "finalcap": "clamp") or the overflow loss or it can become unstable.
-    # of_type: overflow # overflow loss function to force the images back into the [0, 1] range
-    # of_weight: 0.2
-    # fft_type: fft
-    # fft_weight: 0.1
-    # color_criterion: color-l1cosinesim # l1cosinesim naturally helps color consistency, so it is the best to use here, but others can be used as well
-    # color_weight: 1 # Loss based on the UV channels of YUV color space, helps preserve color consistency
-    # avg_criterion: avg-l1
-    # avg_weight: 5 # Averaging downscale loss
-    # ms_criterion: multiscale-l1
-    # ms_weight: 1e-2
-    
-    # Adversarial loss:
-    gan_type: vanilla # "vanilla" | "wgan-gp" | "lsgan" 
-    gan_weight: 5e-3 # * test: 7e-3
-    # for wgan-gp
-    # D_update_ratio: 1
-    # D_init_iters: 0
-    # gp_weigth: 10
-    # if using the discriminator_vgg_128_fea feature maps to calculate feature loss
-    # gan_featmaps: true # true | false
-    # dis_feature_criterion: cb # "l1" | "l2" | "cb" | "elastic" #discriminator feature loss
-    # dis_feature_weight: 0.01 # 1
-    
-    # For PPON
-    # train_phase: 1 # Training starting phase, can skip the first phases
-    # phase1_s: 100 # 5000 #100 #5000 #138000 #-1 to skip. Need to coordinate with the LR steps. #COBranch: lr =  2e−4, decreased by the factor of 2 for every 1000 epochs (1.38e+5 iterations) 138k
-    # phase2_s: 200 # 10000 #200 #10000 #172500 #-1 to skip. Need to coordinate with the LR steps. #SOBranch: λ = 1e+3 (?), lr = 1e−4 and halved at every 250 epochs (3.45e+4iterations) 34.5k
-    # phase3_s: 5000000 # 207000 #-1 to skip. Need to coordinate with the LR steps. #POBranch: η = 5e−3,  lr = 1e−4 and halved at every 250 epochs (3.45e+4iterations) 34.5k
-    # phase4_s: 100100
-    
-    # Differentiable Augmentation for Data-Efficient GAN Training
-    # diffaug: true
-    # dapolicy: 'color,transl_zoom,flip,rotate,cutout' # smart "all" (translation, zoom_in and zoom_out are exclusive)
-    
-    # Batch (Mixup) augmentations
-    # mixup: true
-    # mixopts: [blend, rgb, mixup, cutmix, cutmixup] # , "cutout", "cutblur"]
-    # mixprob: [1.0, 1.0, 1.0, 1.0, 1.0] #, 1.0, 1.0]
-    # mixalpha: [0.6, 1.0, 1.2, 0.7, 0.7] #, 0.001, 0.7]
-    # aux_mixprob: 1.0
-    # aux_mixalpha: 1.2
-    ## mix_p: 1.2
-    
-    # Frequency Separator
-    # fs: true
-    # lpf_type: average # "average" | "gaussian"
-    # hpf_type: average # "average" | "gaussian"
-    
-    # Other training options:
-    # finalcap: clamp # Test. Cap Generator outputs to fit in: [-1, 1] range ("tanh"), rescale tanh to [0,1] range ("scaltanh"), cap ("sigmoid") or clamp ("clamp") to [0,1] range. Default = None. Coordinate with znorm. Required for SPL if using image range [0,1]
-    manual_seed: 0
-    niter: 5e5
-    val_freq: 1000 # 5e3
-    # overwrite_val_imgs: true
-    # val_comparison: true
-    metrics: 'psnr,ssim,lpips' # select from: "psnr,ssim,lpips" or a combination separated by comma ","
+  # == #
+  # > StepLR_Restart (PPON)
+  # lr_gamma: 0.9 #lr change at every step (multiplied by)
+  # lr_scheme: StepLR_Restart # MultiStepLR | MultiStepLR_Restart | StepLR | StepLR_Restart | CosineAnnealingLR_Restart
+  # lr_step_sizes: [200, 100, 250] # Steps for each restart for "StepLR_Restart"
+  # restarts: [138000, 172500] # Restart iterations for "MultiStepLR_Restart", "StepLR_Restart" and "CosineAnnealingLR_Restart"
+  # restart_weights: [1, 0.5, 0.5] #lr_() * each weight in "restart_weights" for each restart in "restarts"
+  # clear_state: false
+  # == #
+
+  # == #
+  # > MultiStepLR_Restart
+  # lr_gamma: 0.9
+  # lr_scheme: MultiStepLR_Restart # MultiStepLR | MultiStepLR_Restart | StepLR | StepLR_Restart | CosineAnnealingLR_Restart
+  # lr_steps: [34500, 69000, 103500, 155250, 189750, 241500] #For "MultiStepLR" and "MultiStepLR_Restart"
+  # restarts: [138000, 172500] # Restart iterations for "MultiStepLR_Restart", "StepLR_Restart" and "CosineAnnealingLR_Restart"
+  # restart_weights: [0.5, 0.5] # lr_() * each weight in "restart_weights" for each restart in "restarts"
+  # clear_state: false
+  # == #
+
+  # == #
+  # > CosineAnnealingLR_Restart (PAN)
+  # lr_G: !!float 7e-4
+  # lr_scheme: "CosineAnnealingLR_Restart"
+  # beta1_G: 0.9
+  # beta2_G: 0.99
+  # lr_D: 7e-4
+  # beta1_D: 0.9
+  # beta2_D: 0.99
+  # # beta1: 0.9
+  # # beta2: 0.99
+  # niter: 1000000
+  # warmup_iter: -1  # no warm up
+  # T_period: [250000, 250000, 250000, 250000]
+  # restarts: [250000, 500000, 750000]
+  # restart_weights: [1, 1, 1]
+  # eta_min: !!float 1e-7
+  # == #
+
+  # == #
+  # > Losses
+  pixel_criterion: cb    # "l1" | "l2" | "cb" | "elastic" | "relativel1" | "l1cosinesim" | "clipl1" #pixel loss
+  pixel_weight: 1e-2     # 1e-2 | 1
+  feature_criterion: cb  # "l1" | "l2" | "cb" | "elastic" # feature loss (VGG feature network)
+  feature_weight: 1
+  # cx_weight: 0.5
+  # cx_type: contextual
+  # cx_vgg_layers: {conv_3_2: 1, conv_4_2: 1}
+  # hfen_criterion: l1 # hfen: "l1" | "l2" | "rel_l1" | "rel_l2" #helps in deblurring and finding edges, lines
+  # hfen_weight: 1e-6
+  # grad_type: grad-4d-l1 # 2d | 4d / - any of the pixel crit, ie "grad-2d-l1"
+  # grad_weight: 4e-1 # 4e-1
+  # tv_type: 4D # "normal" | "4D" #helps in denoising, reducing upscale artefacts
+  # tv_weight: 1e-5 # Change "tv_weight" so the l_g_tv is around 1e-02 - 1e-01
+  # tv_norm: 1 # 1 for l1 (default) or 2 for l2.
+  # ssim_type: ssim # "ssim" | "ms-ssim" #helps to maintain luminance, contrast and covariance between SR and HR
+  # ssim_weight: 1
+  # lpips_weight: 1 # perceptual loss
+  # lpips_type: net-lin # net-lin | net *
+  # lpips_net: squeeze # "vgg" | "alex" | "squeeze"
+  # == #
+
+  # == #
+  # > Experimental losses
+  # spl_type: spl # "spl" | "gpl" | "cpl"
+  # spl_weight: 0.1 # 1e-2 # SPL loss function. note: needs to add a cap in the generator (finalcap; For [0,1] range -> "finalcap": "clamp") or the overflow loss or it can become unstable.
+  # of_type: overflow # overflow loss function to force the images back into the [0, 1] range
+  # of_weight: 0.2
+  # fft_type: fft
+  # fft_weight: 0.1
+  # color_criterion: color-l1cosinesim # l1cosinesim naturally helps color consistency, so it is the best to use here, but others can be used as well
+  # color_weight: 1 # Loss based on the UV channels of YUV color space, helps preserve color consistency
+  # avg_criterion: avg-l1
+  # avg_weight: 5 # Averaging downscale loss
+  # ms_criterion: multiscale-l1
+  # ms_weight: 1e-2
+  # == #
+
+  # == #
+  # > Adversarial loss
+  gan_type: vanilla # "vanilla" | "wgan-gp" | "lsgan"
+  gan_weight: 5e-3 # * test: 7e-3
+  # for wgan-gp
+  # D_update_ratio: 1
+  # D_init_iters: 0
+  # gp_weigth: 10
+  # if using the discriminator_vgg_128_fea feature maps to calculate feature loss
+  # gan_featmaps: true # true | false
+  # dis_feature_criterion: cb # "l1" | "l2" | "cb" | "elastic" #discriminator feature loss
+  # dis_feature_weight: 0.01 # 1
+  # == #
+
+  # For PPON
+  # train_phase: 1 # Training starting phase, can skip the first phases
+  # phase1_s: 100 # 5000 #100 #5000 #138000 #-1 to skip. Need to coordinate with the LR steps. #COBranch: lr =  2e−4, decreased by the factor of 2 for every 1000 epochs (1.38e+5 iterations) 138k
+  # phase2_s: 200 # 10000 #200 #10000 #172500 #-1 to skip. Need to coordinate with the LR steps. #SOBranch: λ = 1e+3 (?), lr = 1e−4 and halved at every 250 epochs (3.45e+4iterations) 34.5k
+  # phase3_s: 5000000 # 207000 #-1 to skip. Need to coordinate with the LR steps. #POBranch: η = 5e−3,  lr = 1e−4 and halved at every 250 epochs (3.45e+4iterations) 34.5k
+  # phase4_s: 100100
+
+  # Differentiable Augmentation for Data-Efficient GAN Training
+  # diffaug: true
+  # dapolicy: 'color,transl_zoom,flip,rotate,cutout' # smart "all" (translation, zoom_in and zoom_out are exclusive)
+
+  # Batch (Mixup) augmentations
+  # mixup: true
+  # mixopts: [blend, rgb, mixup, cutmix, cutmixup] # , "cutout", "cutblur"]
+  # mixprob: [1.0, 1.0, 1.0, 1.0, 1.0] #, 1.0, 1.0]
+  # mixalpha: [0.6, 1.0, 1.2, 0.7, 0.7] #, 0.001, 0.7]
+  # aux_mixprob: 1.0
+  # aux_mixalpha: 1.2
+  ## mix_p: 1.2
+
+  # Frequency Separator
+  # fs: true
+  # lpf_type: average # "average" | "gaussian"
+  # hpf_type: average # "average" | "gaussian"
+
+  # Other training options:
+  # finalcap: clamp # Test. Cap Generator outputs to fit in: [-1, 1] range ("tanh"), rescale tanh to [0,1] range ("scaltanh"), cap ("sigmoid") or clamp ("clamp") to [0,1] range. Default = None. Coordinate with znorm. Required for SPL if using image range [0,1]
+  manual_seed: 0
+  niter: 5e5
+  val_freq: 1000 # 5e3
+  # overwrite_val_imgs: true
+  # val_comparison: true
+  metrics: 'psnr,ssim,lpips' # select from: "psnr,ssim,lpips" or a combination separated by comma ","
 
 logger:
-    print_freq: 200
-    save_checkpoint_freq: 5e3
-    overwrite_chkp: false
+
+  print_freq: 200
+  save_checkpoint_freq: 5e3
+  overwrite_chkp: false


### PR DESCRIPTION
The yml options file is in a very dirty state, this pull request aims to at least clean it up a small bit.

Cleans up stuff like whitespace at end of line, comments in various ways, order of items to make a bit more sense, redundant indentation, small typo's, and more.