### PR TITLE
Add official torchvision Deformable Convolution

### DIFF
--- a/codes/models/modules/architectures/block.py
+++ b/codes/models/modules/architectures/block.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import torch
 import torch.nn as nn
-from models.modules.architectures.convolutions.partialconv2d import PartialConv2d #TODO
+from models.modules.architectures.convolutions.partialconv2d import PartialConv2d, DeformConv2d #TODO
 from models.networks import weights_init_normal, weights_init_kaiming, weights_init_orthogonal
 
 #from modules.architectures.convolutions.partialconv2d import PartialConv2d
@@ -231,6 +231,9 @@ def conv_block(in_nc, out_nc, kernel_size, stride=1, dilation=1, groups=1, bias=
     
     if convtype=='PartialConv2D':
         c = PartialConv2d(in_nc, out_nc, kernel_size=kernel_size, stride=stride, padding=padding, \
+               dilation=dilation, bias=bias, groups=groups)
+    elif convtype=='DeformConv2D':
+        c = DeformConv2d(in_nc, out_nc, kernel_size=kernel_size, stride=stride, padding=padding, \
                dilation=dilation, bias=bias, groups=groups)
     elif convtype=='Conv3D':
         c = nn.Conv3d(in_nc, out_nc, kernel_size=kernel_size, stride=stride, padding=padding, \

--- a/codes/models/modules/architectures/block.py
+++ b/codes/models/modules/architectures/block.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 import torch
 import torch.nn as nn
-from models.modules.architectures.convolutions.partialconv2d import PartialConv2d, DeformConv2d #TODO
+from models.modules.architectures.convolutions.partialconv2d import PartialConv2d #TODO
+from models.modules.architectures.convolutions.deformconv2d import DeformConv2d
 from models.networks import weights_init_normal, weights_init_kaiming, weights_init_orthogonal
 
 #from modules.architectures.convolutions.partialconv2d import PartialConv2d

--- a/codes/models/modules/architectures/convolutions/deformconv2d.py
+++ b/codes/models/modules/architectures/convolutions/deformconv2d.py
@@ -3,14 +3,14 @@ import torchvision.ops as O
 
 
 class DeformConv2d(nn.Module):
-    def __init__(self, in_nc, out_nc, kernel_size=3, stride=1, padding=1, dilation=1, bias=True):
+    def __init__(self, in_nc, out_nc, kernel_size=3, stride=1, padding=1, dilation=1, groups=1, bias=True):
         super(DeformConv2d, self).__init__()
 
         self.conv_offset = nn.Conv2d(in_nc, 2 * (kernel_size**2), kernel_size=kernel_size, stride=stride, padding=padding, bias=bias)
         self.conv_offset.weight.data.zero_()
         self.conv_offset.bias.data.zero_()
 
-        self.dcn_conv = O.DeformConv2d(in_nc, out_nc, kernel_size=kernel_size, stride=stride, padding=padding, dilation=dilation, bias=bias)
+        self.dcn_conv = O.DeformConv2d(in_nc, out_nc, kernel_size=kernel_size, stride=stride, padding=padding, dilation=dilation, groups=groups, bias=bias)
 
     def forward(self, x):
         offset = self.conv_offset(x)

--- a/codes/models/modules/architectures/convolutions/deformconv2d.py
+++ b/codes/models/modules/architectures/convolutions/deformconv2d.py
@@ -1,0 +1,18 @@
+import torch.nn as nn
+import torchvision.ops as O
+
+
+class DeformConv2d(nn.Module):
+    def __init__(self, in_nc, out_nc, kernel_size=3, stride=1, padding=1, dilation=1, bias=True):
+        super(DeformConv2d, self).__init__()
+
+        self.conv_offset = nn.Conv2d(in_nc, 2 * (kernel_size**2), kernel_size=kernel_size, stride=stride, padding=padding, bias=bias)
+        self.conv_offset.weight.data.zero_()
+        self.conv_offset.bias.data.zero_()
+
+        self.dcn_conv = O.DeformConv2d(in_nc, out_nc, kernel_size=kernel_size, stride=stride, padding=padding, dilation=dilation, bias=bias)
+
+    def forward(self, x):
+        offset = self.conv_offset(x)
+        return self.dcn_conv(x, offset=offset)
+

--- a/codes/options/train/train_template.json
+++ b/codes/options/train/train_template.json
@@ -122,7 +122,7 @@
     , "out_nc": 3 //# of output image channels: 3 for RGB and 1 for grayscale
     , "gc": 32
     , "group": 1
-    , "convtype": "Conv2D" //"Conv2D" | "PartialConv2D" | Conv3D
+    , "convtype": "Conv2D" //"Conv2D" | "PartialConv2D" | "DeformConv2D" | "Conv3D"
     , "net_act": "leakyrelu" //"swish" | "leakyrelu"
     , "gaussian": true // true | false
     , "plus": false // true | false

--- a/codes/options/train/train_template.yml
+++ b/codes/options/train/train_template.yml
@@ -118,7 +118,7 @@ network_G:
     out_nc: 3 # of output image channels: 3 for RGB and 1 for grayscale
     gc: 32
     group: 1
-    convtype: Conv2D # Conv2D | PartialConv2D | Conv3D
+    convtype: Conv2D # Conv2D | PartialConv2D | DeformConv2D | Conv3D
     net_act: leakyrelu # swish | leakyrelu
     gaussian: true # true | false
     plus: false # true | false


### PR DESCRIPTION
Added the official torchvision implementation of Deformable Convolution Network (DCN). Able to use with any B.conv_block. 