### PR TITLE
Add EDVR

### DIFF
--- a/codes/models/modules/architectures/EDVR_arch.py
+++ b/codes/models/modules/architectures/EDVR_arch.py
@@ -1,0 +1,485 @@
+import torch
+from torch import nn as nn
+from torch.nn import functional as F
+from torch.nn import init as init
+from torch.nn.modules.batchnorm import _BatchNorm
+
+from . import block as B
+from .convolutions.deformconv2d import DCNv2Pack
+
+
+# TODO: Stardardize with one in block.py
+@torch.no_grad()
+def default_init_weights(module_list, scale=1, bias_fill=0, **kwargs):
+    """Initialize network weights.
+
+    Args:
+        module_list (list[nn.Module] | nn.Module): Modules to be initialized.
+        scale (float): Scale initialized weights, especially for residual
+            blocks. Default: 1.
+        bias_fill (float): The value to fill bias. Default: 0
+        kwargs (dict): Other arguments for initialization function.
+    """
+    if not isinstance(module_list, list):
+        module_list = [module_list]
+    for module in module_list:
+        for m in module.modules():
+            if isinstance(m, nn.Conv2d):
+                init.kaiming_normal_(m.weight, **kwargs)
+                m.weight.data *= scale
+                if m.bias is not None:
+                    m.bias.data.fill_(bias_fill)
+            elif isinstance(m, nn.Linear):
+                init.kaiming_normal_(m.weight, **kwargs)
+                m.weight.data *= scale
+                if m.bias is not None:
+                    m.bias.data.fill_(bias_fill)
+            elif isinstance(m, _BatchNorm):
+                init.constant_(m.weight, 1)
+                if m.bias is not None:
+                    m.bias.data.fill_(bias_fill)
+
+# TODO: Stardardize with one in SrResNet_arch.py
+class ResidualBlockNoBN(nn.Module):
+    """Residual block without BN.
+
+    It has a style of:
+        ---Conv-ReLU-Conv-+-
+         |________________|
+
+    Args:
+        num_feat (int): Channel number of intermediate features.
+            Default: 64.
+        res_scale (float): Residual scale. Default: 1.
+        pytorch_init (bool): If set to True, use pytorch default init,
+            otherwise, use default_init_weights. Default: False.
+    """
+
+    def __init__(self, num_feat=64, res_scale=1, pytorch_init=False):
+        super(ResidualBlockNoBN, self).__init__()
+        self.res_scale = res_scale
+        self.conv1 = nn.Conv2d(num_feat, num_feat, 3, 1, 1, bias=True)
+        self.conv2 = nn.Conv2d(num_feat, num_feat, 3, 1, 1, bias=True)
+        self.relu = nn.ReLU(inplace=True)
+
+        if not pytorch_init:
+            default_init_weights([self.conv1, self.conv2], 0.1)
+
+    def forward(self, x):
+        identity = x
+        out = self.conv2(self.relu(self.conv1(x)))
+        return identity + out * self.res_scale
+
+
+class PCDAlignment(nn.Module):
+    """Alignment module using Pyramid, Cascading and Deformable convolution
+    (PCD). It is used in EDVR.
+
+    Ref:
+        EDVR: Video Restoration with Enhanced Deformable Convolutional Networks
+
+    Args:
+        num_feat (int): Channel number of middle features. Default: 64.
+        deformable_groups (int): Deformable groups. Defaults: 8.
+    """
+
+    def __init__(self, num_feat=64, deformable_groups=8):
+        super(PCDAlignment, self).__init__()
+
+        # Pyramid has three levels:
+        # L3: level 3, 1/4 spatial size
+        # L2: level 2, 1/2 spatial size
+        # L1: level 1, original spatial size
+        self.offset_conv1 = nn.ModuleDict()
+        self.offset_conv2 = nn.ModuleDict()
+        self.offset_conv3 = nn.ModuleDict()
+        self.dcn_pack = nn.ModuleDict()
+        self.feat_conv = nn.ModuleDict()
+
+        # Pyramids
+        for i in range(3, 0, -1):
+            level = f'l{i}'
+            self.offset_conv1[level] = nn.Conv2d(num_feat * 2, num_feat, 3, 1,
+                                                 1)
+            if i == 3:
+                self.offset_conv2[level] = nn.Conv2d(num_feat, num_feat, 3, 1,
+                                                     1)
+            else:
+                self.offset_conv2[level] = nn.Conv2d(num_feat * 2, num_feat, 3,
+                                                     1, 1)
+                self.offset_conv3[level] = nn.Conv2d(num_feat, num_feat, 3, 1,
+                                                     1)
+            self.dcn_pack[level] = DCNv2Pack(
+                num_feat,
+                num_feat,
+                3,
+                padding=1,
+                deformable_groups=deformable_groups)
+
+            if i < 3:
+                self.feat_conv[level] = nn.Conv2d(num_feat * 2, num_feat, 3, 1,
+                                                  1)
+
+        # Cascading dcn
+        self.cas_offset_conv1 = nn.Conv2d(num_feat * 2, num_feat, 3, 1, 1)
+        self.cas_offset_conv2 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+        self.cas_dcnpack = DCNv2Pack(
+            num_feat,
+            num_feat,
+            3,
+            padding=1,
+            deformable_groups=deformable_groups)
+
+        self.upsample = nn.Upsample(
+            scale_factor=2, mode='bilinear', align_corners=False)
+        self.lrelu = nn.LeakyReLU(negative_slope=0.1, inplace=True)
+
+    def forward(self, nbr_feat_l, ref_feat_l):
+        """Align neighboring frame features to the reference frame features.
+
+        Args:
+            nbr_feat_l (list[Tensor]): Neighboring feature list. It
+                contains three pyramid levels (L1, L2, L3),
+                each with shape (b, c, h, w).
+            ref_feat_l (list[Tensor]): Reference feature list. It
+                contains three pyramid levels (L1, L2, L3),
+                each with shape (b, c, h, w).
+
+        Returns:
+            Tensor: Aligned features.
+        """
+        # Pyramids
+        upsampled_offset, upsampled_feat = None, None
+        for i in range(3, 0, -1):
+            level = f'l{i}'
+            offset = torch.cat([nbr_feat_l[i - 1], ref_feat_l[i - 1]], dim=1)
+            offset = self.lrelu(self.offset_conv1[level](offset))
+            if i == 3:
+                offset = self.lrelu(self.offset_conv2[level](offset))
+            else:
+                offset = self.lrelu(self.offset_conv2[level](torch.cat(
+                    [offset, upsampled_offset], dim=1)))
+                offset = self.lrelu(self.offset_conv3[level](offset))
+
+            feat = self.dcn_pack[level](nbr_feat_l[i - 1], offset)
+            if i < 3:
+                feat = self.feat_conv[level](
+                    torch.cat([feat, upsampled_feat], dim=1))
+            if i > 1:
+                feat = self.lrelu(feat)
+
+            if i > 1:  # upsample offset and features
+                # x2: when we upsample the offset, we should also enlarge
+                # the magnitude.
+                upsampled_offset = self.upsample(offset) * 2
+                upsampled_feat = self.upsample(feat)
+
+        # Cascading
+        offset = torch.cat([feat, ref_feat_l[0]], dim=1)
+        offset = self.lrelu(
+            self.cas_offset_conv2(self.lrelu(self.cas_offset_conv1(offset))))
+        feat = self.lrelu(self.cas_dcnpack(feat, offset))
+        return feat
+
+
+class TSAFusion(nn.Module):
+    """Temporal Spatial Attention (TSA) fusion module.
+
+    Temporal: Calculate the correlation between center frame and
+        neighboring frames;
+    Spatial: It has 3 pyramid levels, the attention is similar to SFT.
+        (SFT: Recovering realistic texture in image super-resolution by deep
+            spatial feature transform.)
+
+    Args:
+        num_feat (int): Channel number of middle features. Default: 64.
+        num_frame (int): Number of frames. Default: 5.
+        center_frame_idx (int): The index of center frame. Default: 2.
+    """
+
+    def __init__(self, num_feat=64, num_frame=5, center_frame_idx=2):
+        super(TSAFusion, self).__init__()
+        self.center_frame_idx = center_frame_idx
+        # temporal attention (before fusion conv)
+        self.temporal_attn1 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+        self.temporal_attn2 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+        self.feat_fusion = nn.Conv2d(num_frame * num_feat, num_feat, 1, 1)
+
+        # spatial attention (after fusion conv)
+        self.max_pool = nn.MaxPool2d(3, stride=2, padding=1)
+        self.avg_pool = nn.AvgPool2d(3, stride=2, padding=1)
+        self.spatial_attn1 = nn.Conv2d(num_frame * num_feat, num_feat, 1)
+        self.spatial_attn2 = nn.Conv2d(num_feat * 2, num_feat, 1)
+        self.spatial_attn3 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+        self.spatial_attn4 = nn.Conv2d(num_feat, num_feat, 1)
+        self.spatial_attn5 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+        self.spatial_attn_l1 = nn.Conv2d(num_feat, num_feat, 1)
+        self.spatial_attn_l2 = nn.Conv2d(num_feat * 2, num_feat, 3, 1, 1)
+        self.spatial_attn_l3 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+        self.spatial_attn_add1 = nn.Conv2d(num_feat, num_feat, 1)
+        self.spatial_attn_add2 = nn.Conv2d(num_feat, num_feat, 1)
+
+        self.lrelu = nn.LeakyReLU(negative_slope=0.1, inplace=True)
+        self.upsample = nn.Upsample(
+            scale_factor=2, mode='bilinear', align_corners=False)
+
+    def forward(self, aligned_feat):
+        """
+        Args:
+            aligned_feat (Tensor): Aligned features with shape (b, t, c, h, w).
+
+        Returns:
+            Tensor: Features after TSA with the shape (b, c, h, w).
+        """
+        b, t, c, h, w = aligned_feat.size()
+        # temporal attention
+        embedding_ref = self.temporal_attn1(
+            aligned_feat[:, self.center_frame_idx, :, :, :].clone())
+        embedding = self.temporal_attn2(aligned_feat.view(-1, c, h, w))
+        embedding = embedding.view(b, t, -1, h, w)  # (b, t, c, h, w)
+
+        corr_l = []  # correlation list
+        for i in range(t):
+            emb_neighbor = embedding[:, i, :, :, :]
+            corr = torch.sum(emb_neighbor * embedding_ref, 1)  # (b, h, w)
+            corr_l.append(corr.unsqueeze(1))  # (b, 1, h, w)
+        corr_prob = torch.sigmoid(torch.cat(corr_l, dim=1))  # (b, t, h, w)
+        corr_prob = corr_prob.unsqueeze(2).expand(b, t, c, h, w)
+        corr_prob = corr_prob.contiguous().view(b, -1, h, w)  # (b, t*c, h, w)
+        aligned_feat = aligned_feat.view(b, -1, h, w) * corr_prob
+
+        # fusion
+        feat = self.lrelu(self.feat_fusion(aligned_feat))
+
+        # spatial attention
+        attn = self.lrelu(self.spatial_attn1(aligned_feat))
+        attn_max = self.max_pool(attn)
+        attn_avg = self.avg_pool(attn)
+        attn = self.lrelu(
+            self.spatial_attn2(torch.cat([attn_max, attn_avg], dim=1)))
+        # pyramid levels
+        attn_level = self.lrelu(self.spatial_attn_l1(attn))
+        attn_max = self.max_pool(attn_level)
+        attn_avg = self.avg_pool(attn_level)
+        attn_level = self.lrelu(
+            self.spatial_attn_l2(torch.cat([attn_max, attn_avg], dim=1)))
+        attn_level = self.lrelu(self.spatial_attn_l3(attn_level))
+        attn_level = self.upsample(attn_level)
+
+        attn = self.lrelu(self.spatial_attn3(attn)) + attn_level
+        attn = self.lrelu(self.spatial_attn4(attn))
+        attn = self.upsample(attn)
+        attn = self.spatial_attn5(attn)
+        attn_add = self.spatial_attn_add2(
+            self.lrelu(self.spatial_attn_add1(attn)))
+        attn = torch.sigmoid(attn)
+
+        # after initialization, * 2 makes (attn * 2) to be close to 1.
+        feat = feat * attn * 2 + attn_add
+        return feat
+
+
+class PredeblurModule(nn.Module):
+    """Pre-dublur module.
+
+    Args:
+        num_in_ch (int): Channel number of input image. Default: 3.
+        num_feat (int): Channel number of intermediate features. Default: 64.
+        hr_in (bool): Whether the input has high resolution. Default: False.
+    """
+
+    def __init__(self, num_in_ch=3, num_feat=64, hr_in=False):
+        super(PredeblurModule, self).__init__()
+        self.hr_in = hr_in
+
+        self.conv_first = nn.Conv2d(num_in_ch, num_feat, 3, 1, 1)
+        if self.hr_in:
+            # downsample x4 by stride conv
+            self.stride_conv_hr1 = nn.Conv2d(num_feat, num_feat, 3, 2, 1)
+            self.stride_conv_hr2 = nn.Conv2d(num_feat, num_feat, 3, 2, 1)
+
+        # generate feature pyramid
+        self.stride_conv_l2 = nn.Conv2d(num_feat, num_feat, 3, 2, 1)
+        self.stride_conv_l3 = nn.Conv2d(num_feat, num_feat, 3, 2, 1)
+
+        self.resblock_l3 = ResidualBlockNoBN(num_feat=num_feat)
+        self.resblock_l2_1 = ResidualBlockNoBN(num_feat=num_feat)
+        self.resblock_l2_2 = ResidualBlockNoBN(num_feat=num_feat)
+        self.resblock_l1 = nn.ModuleList(
+            [ResidualBlockNoBN(num_feat=num_feat) for i in range(5)])
+
+        self.upsample = nn.Upsample(
+            scale_factor=2, mode='bilinear', align_corners=False)
+        self.lrelu = nn.LeakyReLU(negative_slope=0.1, inplace=True)
+
+    def forward(self, x):
+        feat_l1 = self.lrelu(self.conv_first(x))
+        if self.hr_in:
+            feat_l1 = self.lrelu(self.stride_conv_hr1(feat_l1))
+            feat_l1 = self.lrelu(self.stride_conv_hr2(feat_l1))
+
+        # generate feature pyramid
+        feat_l2 = self.lrelu(self.stride_conv_l2(feat_l1))
+        feat_l3 = self.lrelu(self.stride_conv_l3(feat_l2))
+
+        feat_l3 = self.upsample(self.resblock_l3(feat_l3))
+        feat_l2 = self.resblock_l2_1(feat_l2) + feat_l3
+        feat_l2 = self.upsample(self.resblock_l2_2(feat_l2))
+
+        for i in range(2):
+            feat_l1 = self.resblock_l1[i](feat_l1)
+        feat_l1 = feat_l1 + feat_l2
+        for i in range(2, 5):
+            feat_l1 = self.resblock_l1[i](feat_l1)
+        return feat_l1
+
+
+class EDVR(nn.Module):
+    """EDVR network structure for video super-resolution.
+
+    Now only support X4 upsampling factor.
+    Paper:
+        EDVR: Video Restoration with Enhanced Deformable Convolutional Networks
+
+    Args:
+        num_in_ch (int): Channel number of input image. Default: 3.
+        num_out_ch (int): Channel number of output image. Default: 3.
+        num_feat (int): Channel number of intermediate features. Default: 64.
+        num_frame (int): Number of input frames. Default: 5.
+        deformable_groups (int): Deformable groups. Defaults: 8.
+        num_extract_block (int): Number of blocks for feature extraction.
+            Default: 5.
+        num_reconstruct_block (int): Number of blocks for reconstruction.
+            Default: 10.
+        center_frame_idx (int): The index of center frame. Frame counting from
+            0. Default: 2.
+        hr_in (bool): Whether the input has high resolution. Default: False.
+        with_predeblur (bool): Whether has predeblur module.
+            Default: False.
+        with_tsa (bool): Whether has TSA module. Default: True.
+    """
+
+    def __init__(self,
+                 num_in_ch=3,
+                 num_out_ch=3,
+                 num_feat=64,
+                 num_frame=5,
+                 deformable_groups=8,
+                 num_extract_block=5,
+                 num_reconstruct_block=10,
+                 center_frame_idx=2,
+                 hr_in=False,
+                 with_predeblur=False,
+                 with_tsa=True):
+        super(EDVR, self).__init__()
+        if center_frame_idx is None:
+            self.center_frame_idx = num_frame // 2
+        else:
+            self.center_frame_idx = center_frame_idx
+        self.hr_in = hr_in
+        self.with_predeblur = with_predeblur
+        self.with_tsa = with_tsa
+
+        # extract features for each frame
+        if self.with_predeblur:
+            self.predeblur = PredeblurModule(
+                num_feat=num_feat, hr_in=self.hr_in)
+            self.conv_1x1 = nn.Conv2d(num_feat, num_feat, 1, 1)
+        else:
+            self.conv_first = nn.Conv2d(num_in_ch, num_feat, 3, 1, 1)
+
+        # extrat pyramid features
+        self.feature_extraction = B.make_layer(
+            ResidualBlockNoBN, num_extract_block, num_feat=num_feat)
+        self.conv_l2_1 = nn.Conv2d(num_feat, num_feat, 3, 2, 1)
+        self.conv_l2_2 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+        self.conv_l3_1 = nn.Conv2d(num_feat, num_feat, 3, 2, 1)
+        self.conv_l3_2 = nn.Conv2d(num_feat, num_feat, 3, 1, 1)
+
+        # pcd and tsa module
+        self.pcd_align = PCDAlignment(
+            num_feat=num_feat, deformable_groups=deformable_groups)
+        if self.with_tsa:
+            self.fusion = TSAFusion(
+                num_feat=num_feat,
+                num_frame=num_frame,
+                center_frame_idx=self.center_frame_idx)
+        else:
+            self.fusion = nn.Conv2d(num_frame * num_feat, num_feat, 1, 1)
+
+        # reconstruction
+        self.reconstruction = B.make_layer(
+            ResidualBlockNoBN, num_reconstruct_block, num_feat=num_feat)
+        # upsample
+        self.upconv1 = nn.Conv2d(num_feat, num_feat * 4, 3, 1, 1)
+        self.upconv2 = nn.Conv2d(num_feat, 64 * 4, 3, 1, 1)
+        self.pixel_shuffle = nn.PixelShuffle(2)
+        self.conv_hr = nn.Conv2d(64, 64, 3, 1, 1)
+        self.conv_last = nn.Conv2d(64, num_out_ch, 3, 1, 1)
+
+        # activation function
+        self.lrelu = nn.LeakyReLU(negative_slope=0.1, inplace=True)
+
+    def forward(self, x):
+        b, t, c, h, w = x.size()
+        if self.hr_in:
+            assert h % 16 == 0 and w % 16 == 0, (
+                'The height and width must be multiple of 16.')
+        else:
+            assert h % 4 == 0 and w % 4 == 0, (
+                'The height and width must be multiple of 4.')
+
+        x_center = x[:, self.center_frame_idx, :, :, :].contiguous()
+
+        # extract features for each frame
+        # L1
+        if self.with_predeblur:
+            feat_l1 = self.conv_1x1(self.predeblur(x.view(-1, c, h, w)))
+            if self.hr_in:
+                h, w = h // 4, w // 4
+        else:
+            feat_l1 = self.lrelu(self.conv_first(x.view(-1, c, h, w)))
+
+        feat_l1 = self.feature_extraction(feat_l1)
+        # L2
+        feat_l2 = self.lrelu(self.conv_l2_1(feat_l1))
+        feat_l2 = self.lrelu(self.conv_l2_2(feat_l2))
+        # L3
+        feat_l3 = self.lrelu(self.conv_l3_1(feat_l2))
+        feat_l3 = self.lrelu(self.conv_l3_2(feat_l3))
+
+        feat_l1 = feat_l1.view(b, t, -1, h, w)
+        feat_l2 = feat_l2.view(b, t, -1, h // 2, w // 2)
+        feat_l3 = feat_l3.view(b, t, -1, h // 4, w // 4)
+
+        # PCD alignment
+        ref_feat_l = [  # reference feature list
+            feat_l1[:, self.center_frame_idx, :, :, :].clone(),
+            feat_l2[:, self.center_frame_idx, :, :, :].clone(),
+            feat_l3[:, self.center_frame_idx, :, :, :].clone()
+        ]
+        aligned_feat = []
+        for i in range(t):
+            nbr_feat_l = [  # neighboring feature list
+                feat_l1[:, i, :, :, :].clone(), feat_l2[:, i, :, :, :].clone(),
+                feat_l3[:, i, :, :, :].clone()
+            ]
+            aligned_feat.append(self.pcd_align(nbr_feat_l, ref_feat_l))
+        aligned_feat = torch.stack(aligned_feat, dim=1)  # (b, t, c, h, w)
+
+        if not self.with_tsa:
+            aligned_feat = aligned_feat.view(b, -1, h, w)
+        feat = self.fusion(aligned_feat)
+
+        out = self.reconstruction(feat)
+        out = self.lrelu(self.pixel_shuffle(self.upconv1(out)))
+        out = self.lrelu(self.pixel_shuffle(self.upconv2(out)))
+        out = self.lrelu(self.conv_hr(out))
+        out = self.conv_last(out)
+        if self.hr_in:
+            base = x_center
+        else:
+            base = F.interpolate(
+                x_center, scale_factor=4, mode='bilinear', align_corners=False)
+        out += base
+        return out

--- a/codes/models/modules/architectures/block.py
+++ b/codes/models/modules/architectures/block.py
@@ -550,7 +550,7 @@ class SelfAttentionBlock(nn.Module):
         
         if self.max_pool: #Upscale to original size
             # out = self.upsample_o(out)
-            out = B.Upsample(size=(input.shape[2],input.shape[3]), mode='bicubic', align_corners=False)(out) #bicubic (PyTorch > 1.0) | bilinear others.
+            out = Upsample(size=(input.shape[2],input.shape[3]), mode='bicubic', align_corners=False)(out) #bicubic (PyTorch > 1.0) | bilinear others.
         
         out = self.gamma*out + input #Add original input
         

--- a/codes/models/modules/architectures/convolutions/deformconv2d.py
+++ b/codes/models/modules/architectures/convolutions/deformconv2d.py
@@ -1,8 +1,18 @@
-import torch.nn as nn
+import math
+import torch
+from torch import nn as nn
+from torch.nn import functional as F
+from torch.nn import init as init
+from torch.nn.modules.batchnorm import _BatchNorm
+from torch.nn.modules.utils import _pair, _single
+
 import torchvision.ops as O
 
 
 class DeformConv2d(nn.Module):
+    """
+    A Custom Deformable Convolution layer that acts similarly to a regular Conv2d layer.
+    """
     def __init__(self, in_nc, out_nc, kernel_size=3, stride=1, padding=1, dilation=1, groups=1, bias=True):
         super(DeformConv2d, self).__init__()
 
@@ -16,3 +26,130 @@ class DeformConv2d(nn.Module):
         offset = self.conv_offset(x)
         return self.dcn_conv(x, offset=offset)
 
+class ModulatedDeformConv(nn.Module):
+    """A Modulated Deformable Conv layer.
+    Args:
+        in_channels (int): Same as nn.Conv2d.
+        out_channels (int): Same as nn.Conv2d.
+        kernel_size (int or tuple[int]): Same as nn.Conv2d.
+        stride (int or tuple[int]): Same as nn.Conv2d.
+        padding (int or tuple[int]): Same as nn.Conv2d.
+        dilation (int or tuple[int]): Same as nn.Conv2d.
+        groups (int): Same as nn.Conv2d.
+        deformable_groups (int): Number of offset groups.
+        bias (bool or str): Same as nn.Conv2d.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0, dilation=1, groups=1, deformable_groups=1, bias=True):
+        super(ModulatedDeformConv, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = _pair(kernel_size)
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+        self.deformable_groups = deformable_groups
+        self.with_bias = bias
+        # enable compatibility with nn.Conv2d
+        self.transposed = False
+        self.output_padding = _single(0)
+
+        self.weight = nn.Parameter(
+            torch.Tensor(out_channels, in_channels // groups,
+                         *self.kernel_size))
+        if bias:
+            self.bias = nn.Parameter(torch.Tensor(out_channels))
+        else:
+            self.register_parameter('bias', None)
+        self.init_weights()
+
+    def init_weights(self):
+        n = self.in_channels
+        for k in self.kernel_size:
+            n *= k
+        stdv = 1. / math.sqrt(n)
+        self.weight.data.uniform_(-stdv, stdv)
+        if self.bias is not None:
+            self.bias.data.zero_()
+
+    def forward(self, x, offset, mask):
+        stride_h, stride_w = _pair(self.stride)
+        pad_h, pad_w = _pair(self.padding)
+        dil_h, dil_w = _pair(self.dilation)
+        _, n_in_channels, _, _ = x.shape
+        n_weight_grps = n_in_channels // self.weight.shape[1]
+        return torch.ops.torchvision.deform_conv2d(x, self.weight, offset, mask, self.bias, stride_h, stride_w, pad_h, pad_w, dil_h, dil_w, n_weight_grps, self.deformable_groups, True)
+
+class ModulatedDeformConvPack(ModulatedDeformConv):
+    """A ModulatedDeformable Conv Encapsulation that acts as normal Conv layers.
+    Args:
+        in_channels (int): Same as nn.Conv2d.
+        out_channels (int): Same as nn.Conv2d.
+        kernel_size (int or tuple[int]): Same as nn.Conv2d.
+        stride (int or tuple[int]): Same as nn.Conv2d.
+        padding (int or tuple[int]): Same as nn.Conv2d.
+        dilation (int or tuple[int]): Same as nn.Conv2d.
+        groups (int): Same as nn.Conv2d.
+        deformable_groups (int): Number of offset groups.
+        bias (bool or str): If specified as `auto`, it will be decided by the
+            norm_cfg. Bias will be set as True if norm_cfg is None, otherwise
+            False.
+    """
+
+    _version = 2
+
+    def __init__(self, *args, **kwargs):
+        super(ModulatedDeformConvPack, self).__init__(*args, **kwargs)
+
+        self.conv_offset = nn.Conv2d(self.in_channels, self.deformable_groups * 3 * self.kernel_size[0] * self.kernel_size[1], kernel_size=self.kernel_size, 
+            stride=_pair(self.stride), padding=_pair(self.padding), dilation=_pair(self.dilation), bias=True)
+        self.init_weights()
+
+    def init_weights(self):
+        super(ModulatedDeformConvPack, self).init_weights()
+        if hasattr(self, 'conv_offset'):
+            self.conv_offset.weight.data.zero_()
+            self.conv_offset.bias.data.zero_()
+
+    def forward(self, x):
+        out = self.conv_offset(x)
+        o1, o2, mask = torch.chunk(out, 3, dim=1)
+        offset = torch.cat((o1, o2), dim=1)
+        mask = torch.sigmoid(mask)
+
+        stride_h, stride_w = _pair(self.stride)
+        pad_h, pad_w = _pair(self.padding)
+        dil_h, dil_w = _pair(self.dilation)
+        _, n_in_channels, _, _ = x.shape
+        n_weight_grps = n_in_channels // self.weight.shape[1]
+        return torch.ops.torchvision.deform_conv2d(x, self.weight, offset, mask, self.bias, stride_h, stride_w, pad_h, pad_w, dil_h, dil_w, n_weight_grps, self.deformable_groups, True)
+
+class DCNv2Pack(ModulatedDeformConvPack):
+    """Modulated deformable conv for deformable alignment.
+
+    Different from the official DCNv2Pack, which generates offsets and masks
+    from the preceding features, this DCNv2Pack takes another different
+    features to generate offsets and masks.
+
+    Ref:
+        Delving Deep into Deformable Alignment in Video Super-Resolution.
+    """
+
+    def forward(self, x, feat):
+        out = self.conv_offset(feat)
+        o1, o2, mask = torch.chunk(out, 3, dim=1)
+        offset = torch.cat((o1, o2), dim=1)
+        mask = torch.sigmoid(mask)
+
+        # TODO: In the official EDVR, this is just a warning. Here I've made it actually interrupt training.
+        # Not sure what to do with it, or if it is even necessary, so I'm leaving it off for now.
+        # offset_absmean = torch.mean(torch.abs(offset))
+        # if offset_absmean > 50:
+        #     raise ValueError(f'Offset abs mean is {offset_absmean}, larger than 50.')
+
+        stride_h, stride_w = _pair(self.stride)
+        pad_h, pad_w = _pair(self.padding)
+        dil_h, dil_w = _pair(self.dilation)
+        _, n_in_channels, _, _ = x.shape
+        n_weight_grps = n_in_channels // self.weight.shape[1]
+        return torch.ops.torchvision.deform_conv2d(x, self.weight, offset, mask, self.bias, stride_h, stride_w, pad_h, pad_w, dil_h, dil_w, n_weight_grps, self.deformable_groups, True)

--- a/codes/models/networks.py
+++ b/codes/models/networks.py
@@ -225,7 +225,7 @@ def define_G(opt, step=0):
         netG = EDVR_arch.EDVR(num_in_ch=opt_net['in_nc'], num_out_ch=opt_net['out_nc'], num_feat=opt_net['nf'], num_frame=opt_net['n_frames'],
                             deformable_groups=opt_net['deformable_groups'], num_extract_block=opt_net['n_extract_block'], 
                             num_reconstruct_block=opt_net['n_reconstruct_block'], center_frame_idx=None, with_predeblur=opt_net['predeblur'], 
-                            with_tsa=opt_net['tsa'], residual_type=opt_net['residual_type'], upsample_mode=opt_net['upsample_mode'])
+                            with_tsa=opt_net['tsa'], residual_type=opt_net['residual_type'], upsample_mode=opt_net['upsample_mode'], upscale=opt_net['scale'])
     else:
         raise NotImplementedError('Generator model [{:s}] not recognized'.format(which_model))
 

--- a/codes/models/networks.py
+++ b/codes/models/networks.py
@@ -225,7 +225,8 @@ def define_G(opt, step=0):
         netG = EDVR_arch.EDVR(num_in_ch=opt_net['in_nc'], num_out_ch=opt_net['out_nc'], num_feat=opt_net['nf'], num_frame=opt_net['n_frames'],
                             deformable_groups=opt_net['deformable_groups'], num_extract_block=opt_net['n_extract_block'], 
                             num_reconstruct_block=opt_net['n_reconstruct_block'], center_frame_idx=None, with_predeblur=opt_net['predeblur'], 
-                            with_tsa=opt_net['tsa'], residual_type=opt_net['residual_type'], upsample_mode=opt_net['upsample_mode'], upscale=opt_net['scale'])
+                            with_tsa=opt_net['tsa'], upsample_mode=opt_net['upsample_mode'], upscale=opt_net['scale'], 
+                            add_rrdb=opt_net['add_rrdb'], nb=opt_net['nb'])
     else:
         raise NotImplementedError('Generator model [{:s}] not recognized'.format(which_model))
 

--- a/codes/models/networks.py
+++ b/codes/models/networks.py
@@ -225,7 +225,7 @@ def define_G(opt, step=0):
         netG = EDVR_arch.EDVR(num_in_ch=opt_net['in_nc'], num_out_ch=opt_net['out_nc'], num_feat=opt_net['nf'], num_frame=opt_net['n_frames'],
                             deformable_groups=opt_net['deformable_groups'], num_extract_block=opt_net['n_extract_block'], 
                             num_reconstruct_block=opt_net['n_reconstruct_block'], center_frame_idx=None, with_predeblur=opt_net['predeblur'], 
-                            with_tsa=opt_net['tsa'])
+                            with_tsa=opt_net['tsa'], residual_type=opt_net['residual_type'], upsample_mode=opt_net['upsample_mode'])
     else:
         raise NotImplementedError('Generator model [{:s}] not recognized'.format(which_model))
 

--- a/codes/models/networks.py
+++ b/codes/models/networks.py
@@ -220,6 +220,12 @@ def define_G(opt, step=0):
     elif which_model == 'DVD_net':
         from models.modules.architectures import DVDNet_arch
         netG = DVDNet_arch.DVDNet(in_nc=opt_net['in_nc'], out_nc=opt_net['out_nc'], nf=opt_net['nf'])
+    elif which_model == 'EDVR_net':
+        from models.modules.architectures import EDVR_arch
+        netG = EDVR_arch.EDVR(num_in_ch=opt_net['in_nc'], num_out_ch=opt_net['out_nc'], num_feat=opt_net['nf'], num_frame=opt_net['n_frames'],
+                            deformable_groups=opt_net['deformable_groups'], num_extract_block=opt_net['n_extract_block'], 
+                            num_reconstruct_block=opt_net['n_reconstruct_block'], center_frame_idx=None, with_predeblur=opt_net['predeblur'], 
+                            with_tsa=opt_net['tsa'])
     else:
         raise NotImplementedError('Generator model [{:s}] not recognized'.format(which_model))
 

--- a/codes/options/test/test_video.yml
+++ b/codes/options/test/test_video.yml
@@ -80,5 +80,6 @@ network_G:
   # n_reconstruct_block: 10 # Number of reconstruction blocks (M=10, L=40)
   # predeblur: false # Use pre-deblur 
   # tsa: true # Use Temporal Spatial Attention
-  # residual_type: RB # RB | RRDB
   # upsample_mode: pixelshuffle # pixelshuffle | upconv
+  # add_rrdb: false # Adds RRDB blocks before upsample step to improve SR
+  # nb: 23 # Only applies to add_rrdb's RRDB blocks

--- a/codes/options/test/test_video.yml
+++ b/codes/options/test/test_video.yml
@@ -80,3 +80,5 @@ network_G:
   # n_reconstruct_block: 10 # Number of reconstruction blocks (M=10, L=40)
   # predeblur: false # Use pre-deblur 
   # tsa: true # Use Temporal Spatial Attention
+  # residual_type: RB # RB | RRDB
+  # upsample_mode: pixelshuffle # pixelshuffle | upconv

--- a/codes/options/test/test_video.yml
+++ b/codes/options/test/test_video.yml
@@ -68,3 +68,15 @@ network_G:
   # gaussian: true # true | false
   # plus: false # true | false
   # ##finalact: tanh # Test. Activation function to make outputs fit in [-1, 1] range. Default = None. Coordinate with znorm.
+
+  # EDVR:
+  # which_model_G: EDVR_net
+  # in_nc: 3 # Number of input image channels: 3 for RGB and 1 for grayscale
+  # out_nc: 3 # Number of output image channels: 3 for RGB and 1 for grayscale
+  # nf: 64 # Number of features (M=64, L=128)
+  # n_frames: 3 # number of frames the network will use to estimate the central frame (n-1)/2. Must coincide with "num_frames" in the dataset.
+  # deformable_groups: 8 # Number of deformable offset groups in the deformable layers
+  # n_extract_block: 5 # Number of extract blocks
+  # n_reconstruct_block: 10 # Number of reconstruction blocks (M=10, L=40)
+  # predeblur: false # Use pre-deblur 
+  # tsa: true # Use Temporal Spatial Attention

--- a/codes/options/train/train_video.yml
+++ b/codes/options/train/train_video.yml
@@ -103,6 +103,8 @@ network_G:
     # n_reconstruct_block: 10 # Number of reconstruction blocks (M=10, L=40)
     # predeblur: false # Use pre-deblur 
     # tsa: true # Use Temporal Spatial Attention
+    # residual_type: RB # RB | RRDB
+    # upsample_mode: pixelshuffle # pixelshuffle | upconv
     
 # Discriminator options:
 network_D:

--- a/codes/options/train/train_video.yml
+++ b/codes/options/train/train_video.yml
@@ -103,8 +103,9 @@ network_G:
     # n_reconstruct_block: 10 # Number of reconstruction blocks (M=10, L=40)
     # predeblur: false # Use pre-deblur 
     # tsa: true # Use Temporal Spatial Attention
-    # residual_type: RB # RB | RRDB
     # upsample_mode: pixelshuffle # pixelshuffle | upconv
+    # add_rrdb: false # Adds RRDB blocks before upsample step to improve SR
+    # nb: 23 # Only applies to add_rrdb's RRDB blocks
     
 # Discriminator options:
 network_D:

--- a/codes/options/train/train_video.yml
+++ b/codes/options/train/train_video.yml
@@ -72,18 +72,18 @@ network_G:
 
     # 3DSR:
     # which_model_G: sr3d_net
-    # nf: 64 # of discrim filters
-    # in_nc: 3 # of input image channels: 3 for RGB and 1 for grayscale
-    # out_nc: 3 # of output image channels: 3 for RGB and 1 for grayscale
+    # nf: 64 # Number of discrim filters
+    # in_nc: 3 # Number of input image channels: 3 for RGB and 1 for grayscale
+    # out_nc: 3 # Number of output image channels: 3 for RGB and 1 for grayscale
 
     # EVSRGAN:
     # which_model_G: RRDB_net # RRDB_net (original ESRGAN arch)
     # norm_type: null
     # mode: CNA
-    # nf: 64 # of discrim filters in the first conv layer
+    # nf: 64 # Number of discrim filters in the first conv layer
     # nb: 23
-    # in_nc: 3 # of input image channels: 3 for RGB and 1 for grayscale
-    # out_nc: 3 # of output image channels: 3 for RGB and 1 for grayscale
+    # in_nc: 3 # Number of input image channels: 3 for RGB and 1 for grayscale
+    # out_nc: 3 # Number of output image channels: 3 for RGB and 1 for grayscale
     # gc: 32
     # group: 1
     # convtype: Conv3D
@@ -91,6 +91,18 @@ network_G:
     # gaussian: true # true | false
     # plus: false # true | false
     # ##finalact: tanh # Test. Activation function to make outputs fit in [-1, 1] range. Default = None. Coordinate with znorm.
+
+    # EDVR:
+    # which_model_G: EDVR_net
+    # in_nc: 3 # Number of input image channels: 3 for RGB and 1 for grayscale
+    # out_nc: 3 # Number of output image channels: 3 for RGB and 1 for grayscale
+    # nf: 64 # Number of features (M=64, L=128)
+    # n_frames: 3 # number of frames the network will use to estimate the central frame (n-1)/2. Must coincide with "num_frames" in the dataset.
+    # deformable_groups: 8 # Number of deformable offset groups in the deformable layers
+    # n_extract_block: 5 # Number of extract blocks
+    # n_reconstruct_block: 10 # Number of reconstruction blocks (M=10, L=40)
+    # predeblur: false # Use pre-deblur 
+    # tsa: true # Use Temporal Spatial Attention
     
 # Discriminator options:
 network_D:

--- a/codes/test_vsr.py
+++ b/codes/test_vsr.py
@@ -63,7 +63,7 @@ def main():
     opt = options.parse(parser.parse_args().opt, is_train=False)
     util.mkdirs((path for key, path in opt['path'].items() if not key == 'pretrain_model_G'))
 
-    util.setup_logger(None, opt['path']['log'], 'test.log', level=logging.INFO, screen=True)
+    logger = util.get_root_logger(None, opt['path']['log'], 'test.log', level=logging.INFO, screen=True)
     logger = logging.getLogger('base')
     logger.info(options.dict2str(opt))
 


### PR DESCRIPTION
Add EDVR using TorchVision's Deformable Convolution implementation. Backward compatible with existing EDVR models, but those must be converted to get the actual state dict information out of the 'params' key.

Extra additions:
- Allow any scale (fully backward compatible)
- Add upsample-block type (pixelshuffle vs upconv)
- optional RRDB layers

Note: This requires torch==1.8.0 and torchvision==0.9.0 (currently prerelease/nightly), may be best to wait until fully updated to merge, but could still be merged with this in mind.